### PR TITLE
Change format to ESM; allows rollup to do its magic

### DIFF
--- a/text.js
+++ b/text.js
@@ -2,8 +2,7 @@
   Text plugin
 */
 exports.translate = function(load) {
-  load.metadata.format = 'amd';
-  return 'def' + 'ine(function() {\nreturn "' + load.source
+  var text = load.source
     .replace(/(["\\])/g, '\\$1')
     .replace(/[\f]/g, "\\f")
     .replace(/[\b]/g, "\\b")
@@ -11,6 +10,13 @@ exports.translate = function(load) {
     .replace(/[\t]/g, "\\t")
     .replace(/[\r]/g, "\\r")
     .replace(/[\u2028]/g, "\\u2028")
-    .replace(/[\u2029]/g, "\\u2029")
-  + '";\n});';
+    .replace(/[\u2029]/g, "\\u2029");
+
+  if(System.transpiler === false) {
+    load.metadata.format = 'amd';
+    return 'def' + 'ine(function() {\nreturn "' + text + '";\n});';
+  }
+
+  load.metadata.format = 'esm';
+  return 'export default "' + source + '";';
 }


### PR DESCRIPTION
AMD and the other formats don't allow rollup to print that sweet, sweet light-blue text -- ESM does