### PR TITLE
enabled esm export code

### DIFF
--- a/text.js
+++ b/text.js
@@ -2,12 +2,11 @@
   Text plugin
 */
 exports.translate = function(load) {
-  if (System.transpiler === false || true) {
+  if (System.transpiler === false) {
     load.metadata.format = 'amd';
     return 'def' + 'ine(function() {\nreturn ' + JSON.stringify(load.source) + ';\n});';
   }
-
-  // disabled pending rollout of https://github.com/systemjs/builder/commit/13ed8f896ab2df733252f75d8ed770c2d9e11862
+  
   load.metadata.format = 'esm';
   return 'export default ' + JSON.stringify(load.source) + ';';
 }


### PR DESCRIPTION
this was disabled pending rollout of systemjs/builder@13ed8f8
adds a workaround for capaj/systemjs-hot-reloader#74 by using 
```
import 'file.html!';
```
 and having 
```
map { 'html': 'text' } 
```
in your config, assuming that text points to this plugin